### PR TITLE
🛠️FIX: #38 onAppear에 viewModel 추가

### DIFF
--- a/Indieplus_Pohang.xcodeproj/project.pbxproj
+++ b/Indieplus_Pohang.xcodeproj/project.pbxproj
@@ -472,6 +472,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Indieplus_Pohang/Preview Content\"";
+				DEVELOPMENT_TEAM = XF4GNZL7MP;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -501,6 +502,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Indieplus_Pohang/Preview Content\"";
+				DEVELOPMENT_TEAM = XF4GNZL7MP;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;

--- a/Indieplus_Pohang/View/MainFlow/DatePickerView.swift
+++ b/Indieplus_Pohang/View/MainFlow/DatePickerView.swift
@@ -29,7 +29,6 @@ struct DatePickerView: View {
 struct DateView: View {
     let today = Date()
     @State var selectedIndex = 0
-//    @State var dateList = Set<String>()
     @State var selectedDate = ""
     
     @StateObject var theatermodel: TheaterManager
@@ -81,12 +80,14 @@ struct DateView: View {
         }
         .onAppear {
             selectedDate = datemodel.dateToList(date: today)
+            moviemodel.getMovieDetail(date: selectedDate)
+            moviemodel.updateCount()
         }
-        .onChange(of: selectedDate) {newValue in
-            
-            movieTitles = moviemodel.movieTitles
-            count = moviemodel.count
-            
-        }
+//        .onChange(of: selectedDate) {newValue in
+//
+//            movieTitles = moviemodel.movieTitles
+//            count = moviemodel.count
+//
+//        }
     }
 }

--- a/Indieplus_Pohang/View/MainFlow/MoviePickerView.swift
+++ b/Indieplus_Pohang/View/MainFlow/MoviePickerView.swift
@@ -14,9 +14,9 @@ struct MoviePickerView: View {
     @ObservedObject var moviemodel: MoviePickerViewModel
 
     @State private var count = 0
-    @State private var movieTitles: [String] = []
-    @State private var movieTimes: [String] = []
-    @State private var movieEngTitles: [String] = []
+//    @State private var movieTitles: [String] = []
+//    @State private var movieTimes: [String] = []
+//    @State private var movieEngTitles: [String] = []
 
     func presentingDifferentTime(index: Int) -> String {
         if index == 0 {
@@ -54,8 +54,6 @@ struct MoviePickerView: View {
                                 .frame(width: 1, height: 60)
                                 .foregroundColor(Color.main)
                         }
-                        
-                        
                         
                         MovieSummaryInfoView(selectedTime: presentingDifferentTime(index: index), theatermodel: theatermodel, moviemodel: moviemodel, index: index)
                             .padding()


### PR DESCRIPTION
## 💡 정리 

- 변경 전 코드
```swift
.onAppear {
            selectedDate = datemodel.dateToList(date: today)
        }
```
selectedDate값만 뷰가 나타날 때 정해줘서는 앱을 열자마자 상영시간표가 보이지 않았다. </br>

- 변경 후 코드
```swift
.onAppear {
            selectedDate = datemodel.dateToList(date: today)
            moviemodel.getMovieDetail(date: selectedDate)
            moviemodel.updateCount()
        }
```

위와 같이 viewmodel의 값들도 할당해주니 상영시간표가 바로 띄워진다.

</br>

```swift
        .onChange(of: selectedDate) {newValue in

            movieTitles = moviemodel.movieTitles
            count = moviemodel.count

        }
```
위의 onChange 매서드는 삭제해도 기능에 문제가 없어서 주석처리했다.
