### PR TITLE
Feat/#41 load web view

### DIFF
--- a/Indieplus-Pohang-Info.plist
+++ b/Indieplus-Pohang-Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
+</dict>
+</plist>

--- a/Indieplus_Pohang.xcodeproj/project.pbxproj
+++ b/Indieplus_Pohang.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		C1217ECA2A821F5F005C4868 /* DatePickerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1217EC92A821F5F005C4868 /* DatePickerViewModel.swift */; };
+		C1217ECD2A8C52D8005C4868 /* TicketingWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1217ECC2A8C52D8005C4868 /* TicketingWebView.swift */; };
+		C1217ECF2A8C5678005C4868 /* TicketingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1217ECE2A8C5678005C4868 /* TicketingViewModel.swift */; };
 		C12630AC2A471D0200F98E2A /* Review.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12630AB2A471D0200F98E2A /* Review.swift */; };
 		C12630B02A48B75600F98E2A /* PosterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12630AF2A48B75600F98E2A /* PosterViewModel.swift */; };
 		C186D12F2A529E080063E6CE /* MovieShowtimeInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C186D12E2A529E080063E6CE /* MovieShowtimeInfo.swift */; };
@@ -36,6 +38,9 @@
 		2F319E6930E28FB7A798DD6C /* Pods-Indieplus_Pohang.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Indieplus_Pohang.debug.xcconfig"; path = "Target Support Files/Pods-Indieplus_Pohang/Pods-Indieplus_Pohang.debug.xcconfig"; sourceTree = "<group>"; };
 		463E30FBC69F18F89F9B9DBD /* Pods-Indieplus_Pohang.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Indieplus_Pohang.release.xcconfig"; path = "Target Support Files/Pods-Indieplus_Pohang/Pods-Indieplus_Pohang.release.xcconfig"; sourceTree = "<group>"; };
 		C1217EC92A821F5F005C4868 /* DatePickerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatePickerViewModel.swift; sourceTree = "<group>"; };
+		C1217ECB2A8C52A6005C4868 /* Indieplus-Pohang-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "Indieplus-Pohang-Info.plist"; sourceTree = SOURCE_ROOT; };
+		C1217ECC2A8C52D8005C4868 /* TicketingWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketingWebView.swift; sourceTree = "<group>"; };
+		C1217ECE2A8C5678005C4868 /* TicketingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketingViewModel.swift; sourceTree = "<group>"; };
 		C12630AB2A471D0200F98E2A /* Review.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Review.swift; path = Indieplus_Pohang/View/Review.swift; sourceTree = SOURCE_ROOT; };
 		C12630AF2A48B75600F98E2A /* PosterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PosterViewModel.swift; sourceTree = "<group>"; };
 		C186D12E2A529E080063E6CE /* MovieShowtimeInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieShowtimeInfo.swift; sourceTree = "<group>"; };
@@ -80,6 +85,7 @@
 				C1B7F79B2A4EE1B4001F1BF9 /* TheaterManager.swift */,
 				C12630AF2A48B75600F98E2A /* PosterViewModel.swift */,
 				C1217EC92A821F5F005C4868 /* DatePickerViewModel.swift */,
+				C1217ECE2A8C5678005C4868 /* TicketingViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -109,6 +115,7 @@
 				C1BED68D2A3D8209007B6A5C /* FastTicketingView.swift */,
 				C1BED68B2A3CC663007B6A5C /* DailyReviewView.swift */,
 				C1BED6912A3DCBB1007B6A5C /* BottomBarView.swift */,
+				C1217ECC2A8C52D8005C4868 /* TicketingWebView.swift */,
 			);
 			path = SubPage;
 			sourceTree = "<group>";
@@ -134,6 +141,7 @@
 		C1BED6712A3AF699007B6A5C /* Indieplus_Pohang */ = {
 			isa = PBXGroup;
 			children = (
+				C1217ECB2A8C52A6005C4868 /* Indieplus-Pohang-Info.plist */,
 				C1217EC52A81ED9D005C4868 /* ViewModel */,
 				C1BED6862A3C2716007B6A5C /* Extension */,
 				C1BED6822A3AF834007B6A5C /* Model */,
@@ -330,6 +338,7 @@
 				C186D12F2A529E080063E6CE /* MovieShowtimeInfo.swift in Sources */,
 				C1B7F7832A497294001F1BF9 /* MoviePickerView.swift in Sources */,
 				C1BED6752A3AF699007B6A5C /* ContentView.swift in Sources */,
+				C1217ECF2A8C5678005C4868 /* TicketingViewModel.swift in Sources */,
 				C186D1312A5560570063E6CE /* MoviePickerViewModel.swift in Sources */,
 				C12630B02A48B75600F98E2A /* PosterViewModel.swift in Sources */,
 				C1B7F79C2A4EE1B4001F1BF9 /* TheaterManager.swift in Sources */,
@@ -338,6 +347,7 @@
 				C1217ECA2A821F5F005C4868 /* DatePickerViewModel.swift in Sources */,
 				C1BED68E2A3D8209007B6A5C /* FastTicketingView.swift in Sources */,
 				C1B7F7862A4972B7001F1BF9 /* Shape+Extension.swift in Sources */,
+				C1217ECD2A8C52D8005C4868 /* TicketingWebView.swift in Sources */,
 				C1BED6852A3AFD93007B6A5C /* MainView.swift in Sources */,
 				C1B7F79E2A4EF1F4001F1BF9 /* TheaterVO.swift in Sources */,
 				C1BED68C2A3CC663007B6A5C /* DailyReviewView.swift in Sources */,
@@ -475,6 +485,7 @@
 				DEVELOPMENT_TEAM = XF4GNZL7MP;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "Indieplus-Pohang-Info.plist";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -505,6 +516,7 @@
 				DEVELOPMENT_TEAM = XF4GNZL7MP;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "Indieplus-Pohang-Info.plist";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/Indieplus_Pohang.xcworkspace/xcuserdata/gyuripark.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/Indieplus_Pohang.xcworkspace/xcuserdata/gyuripark.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Bucket
+   uuid = "EAFC4471-4D2D-49B2-9EA3-B8A6A5FE32A1"
+   type = "0"
+   version = "2.0">
+   <Breakpoints>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "8F78BF5A-DDAF-496D-8E1A-1E3D8B0D261D"
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "Indieplus_Pohang/ViewModel/PosterViewModel.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "9"
+            endingLineNumber = "9"
+            landmarkName = "unknown"
+            landmarkType = "0">
+         </BreakpointContent>
+      </BreakpointProxy>
+   </Breakpoints>
+</Bucket>

--- a/Indieplus_Pohang/Indieplus_PohangApp.swift
+++ b/Indieplus_Pohang/Indieplus_PohangApp.swift
@@ -10,11 +10,12 @@ import SwiftUI
 @main
 struct Indieplus_PohangApp: App {
 //    let model = PosterDataModel()
-    let movie = TheaterManager()
+//    let movie = TheaterManager()
     var body: some Scene {
         WindowGroup {
 //            PosterView(model: model)
             MainView()
+//            TicketingWebView(urlToLoad: "https://www.dtryx.com/cinema/main.do?cgid=FE8EF4D2-F22D-4802-A39A-D58F23A29C1E&BrandCd=indieart&CinemaCd=000057")
 //            TheaterManager()
 //            DatePickerView()
 //            MovieDetailView()

--- a/Indieplus_Pohang/View/MainFlow/MoviePickerView.swift
+++ b/Indieplus_Pohang/View/MainFlow/MoviePickerView.swift
@@ -34,7 +34,7 @@ struct MoviePickerView: View {
     var body: some View {
         VStack(spacing: 30){
             if moviemodel.count == 0 {
-                Text("오늘 상영 중인 영화는 없습니다.")
+                Text("상영 시간표 준비 중입니다.")
                     .foregroundColor(.white)
                     .padding(20)
             }

--- a/Indieplus_Pohang/View/MainView.swift
+++ b/Indieplus_Pohang/View/MainView.swift
@@ -14,7 +14,7 @@ struct MainView: View {
     @ObservedObject var movieModel = MoviePickerViewModel()
     @ObservedObject var dateModel = DatePickerViewModel()
     @ObservedObject var WebViewModel = TicketingWebViewModel()
-    
+        
     var body: some View {
         NavigationView{
             ZStack{
@@ -67,7 +67,7 @@ struct MainView: View {
                 
                 FastTicketingView(viewModel: WebViewModel)
                 
-                BottomBarView()
+                BottomBarView(viewModel: WebViewModel)
             }
         }
         .accentColor(.main)

--- a/Indieplus_Pohang/View/MainView.swift
+++ b/Indieplus_Pohang/View/MainView.swift
@@ -13,6 +13,7 @@ struct MainView: View {
     @ObservedObject var theaterModel = TheaterManager()
     @ObservedObject var movieModel = MoviePickerViewModel()
     @ObservedObject var dateModel = DatePickerViewModel()
+    @ObservedObject var WebViewModel = TicketingWebViewModel()
     
     var body: some View {
         NavigationView{
@@ -64,7 +65,7 @@ struct MainView: View {
                     }
                 }
                 
-                FastTicketingView()
+                FastTicketingView(viewModel: WebViewModel)
                 
                 BottomBarView()
             }

--- a/Indieplus_Pohang/View/Poster/PosterView.swift
+++ b/Indieplus_Pohang/View/Poster/PosterView.swift
@@ -41,7 +41,7 @@ struct PosterView: View {
         }
         .onAppear {
             Task {
-                await model.fetchHTMLParsingResult()
+                model.fetchHTMLParsingResult()
             }
         }
 //        .onAppear {

--- a/Indieplus_Pohang/View/Poster/PosterView.swift
+++ b/Indieplus_Pohang/View/Poster/PosterView.swift
@@ -11,7 +11,6 @@ struct PosterView: View {
     
     @ObservedObject var model: PosterViewModel
 
-    
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack {
@@ -41,9 +40,16 @@ struct PosterView: View {
             }
         }
         .onAppear {
-            // PosterViewController에서 데이터를 가져오는 작업을 시작합니다.
-            model.fetchHTMLParsingResult()
+            Task {
+                await model.fetchHTMLParsingResult()
+            }
         }
+//        .onAppear {
+//            model.fetchHTMLParsingResult()
+//        }
+//        .task {
+//            await model.fetchHTMLParsingResult()
+//        }
     }
 }
 

--- a/Indieplus_Pohang/View/SubPage/BottomBarView.swift
+++ b/Indieplus_Pohang/View/SubPage/BottomBarView.swift
@@ -8,14 +8,20 @@
 import SwiftUI
 
 struct BottomBarView: View {
+    @ObservedObject var viewModel: TicketingWebViewModel
     
-    init() {
+    init(viewModel: TicketingWebViewModel) {
+        
+        self.viewModel = viewModel
+        
+        DispatchQueue.main.async {
             //Use this if NavigationBarTitle is with Large Font
             UINavigationBar.appearance().largeTitleTextAttributes = [.foregroundColor: UIColor(Color.main)]
-
+            
             //Use this if NavigationBarTitle is with displayMode = .inline
             UINavigationBar.appearance().titleTextAttributes = [.foregroundColor: UIColor(Color.main)]
         }
+    }
     
     var body: some View {
             ZStack {
@@ -58,21 +64,25 @@ struct BottomBarView: View {
                 }
                 .offset(x: 130, y: -20)
                 
-                ZStack{
-                    Circle()
-                        .foregroundColor(.black)
-                        .frame(width: 60)
-                        .overlay(Circle()
-                            .strokeBorder(Color.main, lineWidth: 1.3)
-                            .frame(width: 60))
-                    
-                    Image(systemName: "calendar")
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: 35, height: 28)
-                        .foregroundColor(.main)
-                    
+                
+                NavigationLink(destination: TicketingWebView(urlToLoad: "https://www.dtryx.com/cinema/main.do?cgid=FE8EF4D2-F22D-4802-A39A-D58F23A29C1E&BrandCd=indieart&CinemaCd=000057", viewModel: viewModel)) {
+                    ZStack{
+                        Circle()
+                            .foregroundColor(.black)
+                            .frame(width: 60)
+                            .overlay(Circle()
+                                .strokeBorder(Color.main, lineWidth: 1.3)
+                                .frame(width: 60))
+                        
+                        Image(systemName: "calendar")
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 35, height: 28)
+                            .foregroundColor(.main)
+                        
+                    }
                 }
+                
                 .offset(x: 0, y: -50)
                 
             }
@@ -80,8 +90,8 @@ struct BottomBarView: View {
     }
 }
 
-struct BottomBarView_Previews: PreviewProvider {
-    static var previews: some View {
-        BottomBarView()
-    }
-}
+//struct BottomBarView_Previews: PreviewProvider {
+//    static var previews: some View {
+//        BottomBarView()
+//    }
+//}

--- a/Indieplus_Pohang/View/SubPage/FastTicketingView.swift
+++ b/Indieplus_Pohang/View/SubPage/FastTicketingView.swift
@@ -8,8 +8,10 @@
 import SwiftUI
 
 struct FastTicketingView: View {
+    @ObservedObject var viewModel: TicketingWebViewModel
+    
     var body: some View {
-        Button {} label : {
+        NavigationLink(destination: TicketingWebView(urlToLoad: "https://www.dtryx.com/cinema/main.do?cgid=FE8EF4D2-F22D-4802-A39A-D58F23A29C1E&BrandCd=indieart&CinemaCd=000057", viewModel: viewModel)) {
             ZStack {
                 Rectangle()
                     .frame(width: 100, height: 40)
@@ -24,8 +26,8 @@ struct FastTicketingView: View {
     }
 }
 
-struct FastTicketingView_Previews: PreviewProvider {
-    static var previews: some View {
-        FastTicketingView()
-    }
-}
+//struct FastTicketingView_Previews: PreviewProvider {
+//    static var previews: some View {
+//        FastTicketingView()
+//    }
+//}

--- a/Indieplus_Pohang/View/SubPage/TicketingWebView.swift
+++ b/Indieplus_Pohang/View/SubPage/TicketingWebView.swift
@@ -1,0 +1,42 @@
+//
+//  TicketingWebView.swift
+//  Indieplus_Pohang
+//
+//  Created by GYURI PARK on 2023/08/16.
+//
+
+import SwiftUI
+import WebKit
+
+struct TicketingWebView: UIViewRepresentable {
+    
+    var urlToLoad: String
+    @ObservedObject var viewModel: TicketingWebViewModel
+    
+    
+    // 뷰 객체를 생성하고 초기 상태를 구성합니다. 딱 한 번만 호출됩니다.
+    func makeUIView(context: Context) -> WKWebView {
+        
+        // unwrapping
+        guard let url = URL(string: self.urlToLoad) else {
+            return WKWebView()
+        }
+        
+        // 웹뷰 인스턴스 생성
+        let webView = WKWebView()
+        
+        // WebView 로드
+        webView.load(URLRequest(url: url))
+        return webView
+    }
+    
+    // update UIView
+    func updateUIView(_ uiView: WKWebView, context: UIViewRepresentableContext<TicketingWebView>) {
+        
+    }
+    
+    // 탐색 변경을 수락 또는 거부하고 탐색 요청의 진행 상황을 추적
+//    class Coordinator : NSObject, WKNavigationDelegate {
+//        
+//    }
+}

--- a/Indieplus_Pohang/ViewModel/PosterViewModel.swift
+++ b/Indieplus_Pohang/ViewModel/PosterViewModel.swift
@@ -5,9 +5,9 @@
 //  Created by GYURI PARK on 2023/06/26.
 //
 
-//import Foundation
-//import SwiftSoup
-//
+import Foundation
+import SwiftSoup
+
 //class PosterViewModel: ObservableObject {
 //    @Published var movieData: [[String: String]] = []
 //    @Published var movieCount = 0
@@ -125,7 +125,7 @@
 //
 //                if (200..<300).contains(response.statusCode), let data = data {
 //                    do {
-//                        let html = try String(data: data, encoding: .utf8)
+//                        let html = String(data: data, encoding: .utf8)
 //                        let doc: Document = try SwiftSoup.parse(html!)
 //
 //                        let thumElements: Elements = try doc.select(".thum")

--- a/Indieplus_Pohang/ViewModel/PosterViewModel.swift
+++ b/Indieplus_Pohang/ViewModel/PosterViewModel.swift
@@ -5,48 +5,211 @@
 //  Created by GYURI PARK on 2023/06/26.
 //
 
+//import Foundation
+//import SwiftSoup
+//
+//class PosterViewModel: ObservableObject {
+//    @Published var movieData: [[String: String]] = []
+//    @Published var movieCount = 0
+
+// MARK: 1. DispatchQueue 사용
+//    init() {
+//        fetchHTMLParsingResult()
+//    }
+//
+//    func fetchHTMLParsingResult() {
+//        let urlAddress = "https://www.dtryx.com/cinema/main.do?cgid=FE8EF4D2-F22D-4802-A39A-D58F23A29C1E&BrandCd=indieart&CinemaCd=000057"
+//        guard let url = URL(string: urlAddress) else {
+//            return
+//        }
+//
+//        DispatchQueue.global().async {
+//            do {
+//                let html = try String(contentsOf: url, encoding: .utf8)
+//                let doc: Document = try SwiftSoup.parse(html)
+//
+//                let thumElements: Elements = try doc.select(".thum")
+//
+//                var movieData: [[String: String]] = []
+//
+//                for thumElement in thumElements {
+//                    guard let imgElement = try thumElement.select("img").first(),
+//                          let movieTitle = try thumElement.select(".subj").first()?.text() else {
+//                        continue
+//                    }
+//
+//                    let imgSource = try imgElement.attr("src")
+//                    let movieDict: [String: String] = ["imgSource": imgSource, "movieTitle": movieTitle]
+//                    movieData.append(movieDict)
+//                }
+//
+//                DispatchQueue.main.async {
+//                    self.movieData = movieData
+//                    self.movieCount = movieData.count
+//                }
+//            }
+//            catch {
+//                print("error", error.localizedDescription)
+//            }
+//        }
+//    }
+
+    
+    // MARK: 2. async / await 사용
+//    func fetchHTMLPardsingResult() async {
+//        let urlAddress = "https://www.dtryx.com/cinema/main.do?cgid=FE8EF4D2-F22D-4802-A39A-D58F23A29C1E&BrandCd=indieart&CinemaCd=000057"
+//
+//        guard let url = URL(string: urlAddress) else {
+//            return
+//        }
+//
+//        do {
+//            let html = try String(contentsOf: url, encoding: .utf8)
+//            let doc: Document = try SwiftSoup.parse(html)
+//
+//            let thumElements: Elements = try doc.select(".thum")
+//
+//            var movieData: [[String: String]] = []
+//
+//            for thumElement in thumElements {
+//                guard let imgElement = try thumElement.select("img").first(),
+//                      let movieTitle = try thumElement.select(".subj").first()?.text() else {
+//                    continue
+//                }
+//
+//                let imgSource = try imgElement.attr("src")
+//                let movieDict: [String: String] = ["imgSource": imgSource, "movieTitle": movieTitle]
+//                movieData.append(movieDict)
+//            }
+//
+//            await setData(movieData: movieData)
+//
+//        } catch {
+//            print("error", error.localizedDescription)
+//        }
+//    }
+//
+//    @MainActor
+//    private func setData(movieData: [[String: String]]) {
+//        self.movieData = movieData
+//        self.movieCount = movieData.count
+//    }
+//
+//
+    // MARK: 3. URLSession 사용
+//    func fetchHTMLParsingResult() {
+//
+//        // URL 생성
+//        guard let url = URL(string: "https://www.dtryx.com/cinema/main.do?cgid=FE8EF4D2-F22D-4802-A39A-D58F23A29C1E&BrandCd=indieart&CinemaCd=000057") else {
+//            return
+//        }
+//
+//        // URLRequest 설정
+//        var request = URLRequest(url: url)
+//        request.httpMethod = "GET"
+//
+//        // URLSession 생성 (기본 세션)
+//        let session = URLSession(configuration: .default)
+//
+//        // dataTask
+//        let task = session.dataTask(with: request) { [weak self] (data, response, error) in
+//            guard let self = self else { return }
+//
+//            if let error = error {
+//                print("Error:", error.localizedDescription)
+//                return
+//            }
+//
+//            if let response = response as? HTTPURLResponse {
+//                print("Status code:", response.statusCode)
+//
+//                if (200..<300).contains(response.statusCode), let data = data {
+//                    do {
+//                        let html = try String(data: data, encoding: .utf8)
+//                        let doc: Document = try SwiftSoup.parse(html!)
+//
+//                        let thumElements: Elements = try doc.select(".thum")
+//
+//                        var movieData: [[String: String]] = []
+//
+//                        for thumElement in thumElements {
+//                            guard let imgElement = try thumElement.select("img").first(),
+//                                  let movieTitle = try thumElement.select(".subj").first()?.text() else {
+//                                continue
+//                            }
+//
+//                            let imgSource = try imgElement.attr("src")
+//                            let movieDict: [String: String] = ["imgSource": imgSource, "movieTitle": movieTitle]
+//                            movieData.append(movieDict)
+//                        }
+//
+//                        DispatchQueue.main.async {
+//                            self.movieData = movieData
+//                            self.movieCount = movieData.count
+//                        }
+//                    } catch {
+//                        print("Error parsing HTML:", error.localizedDescription)
+//                    }
+//                } else {
+//                    print("Request failed with status code:", response.statusCode)
+//                }
+//            }
+//        }
+//        task.resume()
+//    }
+//}
+
+
+// MARK: 4. Combine 사용
 import Foundation
 import SwiftSoup
+import Combine
 
 class PosterViewModel: ObservableObject {
     @Published var movieData: [[String: String]] = []
     @Published var movieCount = 0
+    private var cancellables: Set<AnyCancellable> = []
 
-    init() {
-        fetchHTMLParsingResult()
-    }
-    
     func fetchHTMLParsingResult() {
-        let urlAddress = "https://www.dtryx.com/cinema/main.do?cgid=FE8EF4D2-F22D-4802-A39A-D58F23A29C1E&BrandCd=indieart&CinemaCd=000057"
-        guard let url = URL(string: urlAddress) else {
+        guard let url = URL(string: "https://www.dtryx.com/cinema/main.do?cgid=FE8EF4D2-F22D-4802-A39A-D58F23A29C1E&BrandCd=indieart&CinemaCd=000057") else {
             return
         }
-        
-        DispatchQueue.global().async {
-            do {
-                let html = try String(contentsOf: url, encoding: .utf8)
-                let doc: Document = try SwiftSoup.parse(html)
-                
-                let thumElements: Elements = try doc.select(".thum")
-                
+
+        URLSession.shared.dataTaskPublisher(for: url)
+            .map(\.data)
+            .compactMap { data -> String? in
+                String(data: data, encoding: .utf8)
+            }
+            .tryMap { html -> [[String: String]] in
+                let doc = try SwiftSoup.parse(html)
+                let thumElements = try doc.select(".thum")
+
                 var movieData: [[String: String]] = []
-                
+
                 for thumElement in thumElements {
-                    guard let imgElement = try thumElement.select("img").first(),
-                          let movieTitle = try thumElement.select(".subj").first()?.text() else {
-                        continue
+                    if let imgElement = try? thumElement.select("img").first(),
+                       let movieTitle = try? thumElement.select(".subj").first()?.text() {
+
+                        let imgSource = try? imgElement.attr("src")
+                        let movieDict: [String: String] = ["imgSource": imgSource ?? "", "movieTitle": movieTitle]
+                        movieData.append(movieDict)
                     }
-                    
-                    let imgSource = try imgElement.attr("src")
-                    let movieDict: [String: String] = ["imgSource": imgSource, "movieTitle": movieTitle]
-                    movieData.append(movieDict)
                 }
-                
-                DispatchQueue.main.async {
-                    self.movieData = movieData
-                    self.movieCount = movieData.count
+
+                return movieData
+            }
+            .receive(on: DispatchQueue.main)
+            .sink(
+                receiveCompletion: {
+                    completion in
+                if case .failure(let error) = completion {
+                    print("Error:", error.localizedDescription)
                 }
-            } catch { }
-        }
+            },
+                receiveValue: { [weak self] movieData in
+                self?.movieData = movieData
+                self?.movieCount = movieData.count
+            })
+            .store(in: &cancellables)
     }
 }

--- a/Indieplus_Pohang/ViewModel/TicketingViewModel.swift
+++ b/Indieplus_Pohang/ViewModel/TicketingViewModel.swift
@@ -1,0 +1,15 @@
+//
+//  TicketingViewModel.swift
+//  Indieplus_Pohang
+//
+//  Created by GYURI PARK on 2023/08/16.
+//
+
+import Foundation
+import Combine
+
+class TicketingWebViewModel: ObservableObject {
+    var foo = PassthroughSubject<Bool, Never>()
+    var bar = PassthroughSubject<Bool, Never>()
+}
+

--- a/Indieplus_Pohang/ViewModel/TicketingViewModel.swift
+++ b/Indieplus_Pohang/ViewModel/TicketingViewModel.swift
@@ -11,5 +11,7 @@ import Combine
 class TicketingWebViewModel: ObservableObject {
     var foo = PassthroughSubject<Bool, Never>()
     var bar = PassthroughSubject<Bool, Never>()
+    
+    var cancellables: Set<AnyCancellable> = []
 }
 


### PR DESCRIPTION
## 💡 정리

- WebKit의 기본 함수들을 사용하여 WebView를 띄웁니다.
```swift
struct TicketingWebView: UIViewRepresentable {
    
    var urlToLoad: String
    @ObservedObject var viewModel: TicketingWebViewModel
    
    
    // 뷰 객체를 생성하고 초기 상태를 구성합니다. 딱 한 번만 호출됩니다.
    func makeUIView(context: Context) -> WKWebView {
        
        // unwrapping
        guard let url = URL(string: self.urlToLoad) else {
            return WKWebView()
        }
        
        // 웹뷰 인스턴스 생성
        let webView = WKWebView()
        
        // WebView 로드
        webView.load(URLRequest(url: url))
        return webView
    }
    
    // update UIView
    func updateUIView(_ uiView: WKWebView, context: UIViewRepresentableContext<TicketingWebView>) {
        
    }
}

```
</br>

### 오류 내용 

<img width="754" alt="Pasted Graphic 9" src="https://github.com/GYURI-PARK/Indieplus_Pohang/assets/93391058/2f3268b8-dba7-45c9-91c5-eb19b98e6a6b">

>  웹 뷰를 로드하는 작업(webView.load(URLRequest(url: url)))이 메인 스레드에서 실행되면서 발생한 것으로 생각했습니다. 웹 페이지 로딩은 네트워크 작업이 포함되므로 시간이 오래 걸릴 수 있기 때문에 이러한 작업을 메인 스레드에서 실행하면 UI가 블로킹되어 렌더링 및 이벤트 처리가 중단될 수 있습니다.

### 수정 코드

```swift
import SwiftUI
import Combine
import WebKit

struct TicketingWebView: UIViewRepresentable {
    var urlToLoad: String
    @ObservedObject var viewModel: TicketingWebViewModel
    
    func makeUIView(context: Context) -> WKWebView {
        let webView = WKWebView()
        return webView
    }

    func updateUIView(_ uiView: WKWebView, context: Context) {
        guard let url = URL(string: urlToLoad) else { return }

        URLSession.shared.dataTaskPublisher(for: url)
            .map { $0.data }
            .receive(on: DispatchQueue.main) // UI 업데이트는 메인 스레드에서 수행
            .sink(receiveCompletion: { _ in }) { data in
                uiView.load(data, mimeType: "text/html", characterEncodingName: "utf-8", baseURL: url)
            }
            .store(in: &viewModel.cancellables) // 뷰 모델의 cancellables에 저장
    }
}
```
> Combine을 사용하여 웹 뷰 로딩을 비동기 처리 </br>

```swift
@ObservedObject var viewModel: TicketingWebViewModel
    
    init(viewModel: TicketingWebViewModel) {
        
        self.viewModel = viewModel
        //Use this if NavigationBarTitle is with Large Font
        UINavigationBar.appearance().largeTitleTextAttributes = [.foregroundColor: UIColor(Color.main)]
        
        //Use this if NavigationBarTitle is with displayMode = .inline
        UINavigationBar.appearance().titleTextAttributes = [.foregroundColor: UIColor(Color.main)]
    }
```
> BottomBarView에 정의되어 있는 TicketingWebViewModel 초기화 작업 또한 백그라운드 스레드에서 실행하도록 수정 </br>

## 📱 구현한 UI

![Simulator Screen Recording - iPhone 14 Pro - 2023-08-29 at 22 19 32](https://github.com/GYURI-PARK/Indieplus_Pohang/assets/93391058/08564088-4166-4c9e-ab0c-724d7ca9b23f)
