### PR TITLE
♻️[REFACTOR] #57 모든 기기 사이즈에 대해 대응합니다.

### DIFF
--- a/Indieplus_Pohang.xcodeproj/project.pbxproj
+++ b/Indieplus_Pohang.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		C157600E2AEAEA590089FFE5 /* TimeTableModalModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C157600D2AEAEA590089FFE5 /* TimeTableModalModel.swift */; };
 		C15760122AED75D00089FFE5 /* SplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15760112AED75D00089FFE5 /* SplashView.swift */; };
 		C186D1312A5560570063E6CE /* MoviePickerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C186D1302A5560570063E6CE /* MoviePickerViewModel.swift */; };
+		C19604222B0656D000432FC0 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = C19604212B0656D000432FC0 /* Constants.swift */; };
 		C19AFB002AE6AA410037A5F5 /* TimeTableModal.swift in Sources */ = {isa = PBXBuildFile; fileRef = C19AFAFF2AE6AA410037A5F5 /* TimeTableModal.swift */; };
 		C19AFB0C2AE6B0EA0037A5F5 /* Pretendard-ExtraLight.otf in Resources */ = {isa = PBXBuildFile; fileRef = C19AFB032AE6B0E90037A5F5 /* Pretendard-ExtraLight.otf */; };
 		C19AFB0D2AE6B0EA0037A5F5 /* Pretendard-Black.otf in Resources */ = {isa = PBXBuildFile; fileRef = C19AFB042AE6B0E90037A5F5 /* Pretendard-Black.otf */; };
@@ -58,6 +59,7 @@
 		C157600D2AEAEA590089FFE5 /* TimeTableModalModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeTableModalModel.swift; sourceTree = "<group>"; tabWidth = 3; };
 		C15760112AED75D00089FFE5 /* SplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashView.swift; sourceTree = "<group>"; };
 		C186D1302A5560570063E6CE /* MoviePickerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoviePickerViewModel.swift; sourceTree = "<group>"; };
+		C19604212B0656D000432FC0 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		C19AFAFF2AE6AA410037A5F5 /* TimeTableModal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeTableModal.swift; sourceTree = "<group>"; };
 		C19AFB032AE6B0E90037A5F5 /* Pretendard-ExtraLight.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-ExtraLight.otf"; sourceTree = "<group>"; };
 		C19AFB042AE6B0E90037A5F5 /* Pretendard-Black.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Black.otf"; sourceTree = "<group>"; };
@@ -147,6 +149,14 @@
 			path = SubPage;
 			sourceTree = "<group>";
 		};
+		C19604202B0656AD00432FC0 /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				C19604212B0656D000432FC0 /* Constants.swift */,
+			);
+			path = Utils;
+			sourceTree = "<group>";
+		};
 		C19AFB012AE6B0500037A5F5 /* DesignSystem */ = {
 			isa = PBXGroup;
 			children = (
@@ -193,6 +203,7 @@
 		C1BED6712A3AF699007B6A5C /* Indieplus_Pohang */ = {
 			isa = PBXGroup;
 			children = (
+				C19604202B0656AD00432FC0 /* Utils */,
 				C19AFB012AE6B0500037A5F5 /* DesignSystem */,
 				C1217ECB2A8C52A6005C4868 /* Indieplus-Pohang-Info.plist */,
 				C1217EC52A81ED9D005C4868 /* ViewModel */,
@@ -399,6 +410,7 @@
 				C1B7F7982A4D6D93001F1BF9 /* TheaterView.swift in Sources */,
 				C1B7F7832A497294001F1BF9 /* MoviePickerView.swift in Sources */,
 				C15760122AED75D00089FFE5 /* SplashView.swift in Sources */,
+				C19604222B0656D000432FC0 /* Constants.swift in Sources */,
 				C1BED6752A3AF699007B6A5C /* ContentView.swift in Sources */,
 				C1217ECF2A8C5678005C4868 /* LoadingWebViewModel.swift in Sources */,
 				C186D1312A5560570063E6CE /* MoviePickerViewModel.swift in Sources */,

--- a/Indieplus_Pohang/Utils/Constants.swift
+++ b/Indieplus_Pohang/Utils/Constants.swift
@@ -1,0 +1,35 @@
+//
+//  Constants.swift
+//  Indieplus_Pohang
+//
+//  Created by GYURI PARK on 2023/11/16.
+//
+
+import Foundation
+import SwiftUI
+
+struct Constants {
+    
+    static var bottomOffset: Double {
+        switch UIScreen.main.bounds.size {
+        case CGSize(width: 430, height: 932): // 14 Pro Max
+            return 370.0
+        case CGSize(width: 393, height: 852): // 14 Pro
+            return 350.0
+        case CGSize(width: 428, height: 926): // 14 Plus, 13 Pro Max, 12 Pro Max
+            return 370.0
+        case CGSize(width: 390, height: 844): // 14, 13 Pro, 13, 12 Pro, 12
+            return 350.0
+        case CGSize(width: 375, height: 667): // SE
+            return 250.0
+        case CGSize(width: 375, height: 812): // 13 Mini, 12 Mini, 11 Pro, XS
+            return 330.0
+        case CGSize(width: 375, height: 780): // 13 Mini, 12 Mini
+            return 330.0
+        case CGSize(width: 414, height: 896): // 11 Pro Max, 11, XS Max, XR
+            return 365.0
+        default:
+            return 250.0
+        }
+    }
+}

--- a/Indieplus_Pohang/Utils/Constants.swift
+++ b/Indieplus_Pohang/Utils/Constants.swift
@@ -21,7 +21,7 @@ struct Constants {
         case CGSize(width: 390, height: 844): // 14, 13 Pro, 13, 12 Pro, 12
             return 350.0
         case CGSize(width: 375, height: 667): // SE
-            return 250.0
+            return 265.0
         case CGSize(width: 375, height: 812): // 13 Mini, 12 Mini, 11 Pro, XS
             return 330.0
         case CGSize(width: 375, height: 780): // 13 Mini, 12 Mini

--- a/Indieplus_Pohang/View/SubPage/BottomBarView.swift
+++ b/Indieplus_Pohang/View/SubPage/BottomBarView.swift
@@ -27,67 +27,69 @@ struct BottomBarView: View {
     }
     
     var body: some View {
-        ZStack {
-            Rectangle()
-                .frame(width: 400, height: 98)
-                .foregroundStyle(Color.main)
-                .ignoresSafeArea()
-            
-            NavigationLink {
-                TheaterView()
-                    .navigationBarTitle("INDIE PLUS POHANG")
-                    .navigationBarTitleDisplayMode(.inline)
-                    .accentColor(.main)
-            } label : {
-                VStack{
-                    Image(systemName: "house")
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: 36)
+        GeometryReader { geometry in
+            ZStack {
+                Rectangle()
+                    .frame(width: geometry.size.width, height: 98)
+                    .foregroundStyle(Color.main)
+                    .ignoresSafeArea()
+                
+                NavigationLink {
+                    TheaterView()
+                        .navigationBarTitle("INDIE PLUS POHANG")
+                        .navigationBarTitleDisplayMode(.inline)
+                        .accentColor(.main)
+                } label : {
+                    VStack{
+                        Image(systemName: "house")
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 36)
+                    }
+                    .foregroundStyle(.black)
                 }
-                .foregroundStyle(.black)
-            }
-            .offset(x: -130, y: -20)
-            
-            NavigationLink(destination: LoadingWebView(urlToLoad: "https://culturalspace.phcf.or.kr/joongangArtHall/intro.do", viewModel: viewModel)) {
-                VStack{
-                    Image(systemName: "globe")
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: 28)
+                .offset(x: -130, y: -20)
+                
+                NavigationLink(destination: LoadingWebView(urlToLoad: "https://culturalspace.phcf.or.kr/joongangArtHall/intro.do", viewModel: viewModel)) {
+                    VStack{
+                        Image(systemName: "globe")
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 28)
+                    }
+                    .foregroundStyle(Color.black)
                 }
-                .foregroundStyle(Color.black)
-            }
-            .offset(x: 130, y: -20)
-            
-            
-            Button(action: {
-                isModalShown.toggle()
-            }) {
-                ZStack{
-                    Circle()
-                        .foregroundStyle(.black)
-                        .frame(width: 60)
-                        .overlay(Circle()
-                            .strokeBorder(Color.main, lineWidth: 1.3)
-                            .frame(width: 60))
-                    
-                    Image(systemName: "calendar")
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: 35, height: 28)
-                        .foregroundStyle(Color.main)
-                    
+                .offset(x: 130, y: -20)
+                
+                
+                Button(action: {
+                    isModalShown.toggle()
+                }) {
+                    ZStack{
+                        Circle()
+                            .foregroundStyle(.black)
+                            .frame(width: 60)
+                            .overlay(Circle()
+                                .strokeBorder(Color.main, lineWidth: 1.3)
+                                .frame(width: 60))
+                        
+                        Image(systemName: "calendar")
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 35, height: 28)
+                            .foregroundStyle(Color.main)
+                        
+                    }
                 }
+                
+                .offset(x: 0, y: -50)
+                
             }
-            
-            .offset(x: 0, y: -50)
-            
-        }
-        .offset(y: 400)
-        .sheet(isPresented: $isModalShown) {
-            TimeTableModal()
-                .presentationDetents([.height(180)])
+            .offset(y: geometry.size.height / 2 + Constants.bottomOffset)
+            .sheet(isPresented: $isModalShown) {
+                TimeTableModal()
+                    .presentationDetents([.height(180)])
+            }
         }
     }
 }

--- a/Indieplus_Pohang/View/SubPage/FastTicketingView.swift
+++ b/Indieplus_Pohang/View/SubPage/FastTicketingView.swift
@@ -12,19 +12,21 @@ struct FastTicketingView: View {
     @Environment(\.dismiss) private var dismiss
     
     var body: some View {
-        NavigationLink(destination: LoadingWebView(urlToLoad: "https://www.dtryx.com/cinema/main.do?cgid=FE8EF4D2-F22D-4802-A39A-D58F23A29C1E&BrandCd=indieart&CinemaCd=000057", viewModel: viewModel)) {
-            ZStack {
-                Rectangle()
-                    .frame(width: 100, height: 40)
-                    .foregroundStyle(Color.main)
-                    .cornerRadius(10, corners: [.bottomLeft, .topLeft])
-                
-                Text("빠른 예매")
-                    .font(.system(size: 17, weight: .bold))
-                    .foregroundStyle(Color.black)
+        GeometryReader { geometry in
+            NavigationLink(destination: LoadingWebView(urlToLoad: "https://www.dtryx.com/cinema/main.do?cgid=FE8EF4D2-F22D-4802-A39A-D58F23A29C1E&BrandCd=indieart&CinemaCd=000057", viewModel: viewModel)) {
+                ZStack {
+                    Rectangle()
+                        .frame(width: 100, height: 40)
+                        .foregroundStyle(Color.main)
+                        .cornerRadius(10, corners: [.bottomLeft, .topLeft])
+                    
+                    Text("빠른 예매")
+                        .font(.system(size: 17, weight: .bold))
+                        .foregroundStyle(Color.black)
+                }
             }
+            .offset(x: geometry.size.width - 100, y: geometry.size.height / 2 + Constants.bottomOffset - 60)
         }
-        .offset(x: 151, y: 318)
     }
 }
 


### PR DESCRIPTION
## 👀 ISSUES

- #57

## 💡 정리

인디플러스 포항은 현재 iOS 16.2이상을 지원하고 있습니다.
따라서 16.2이상을 지원하는 모든 iPhone기기 사이즈에 대응할 수 있도록 코드를 수정하였습니다.

- 16.2이상을 지원하는 기기와 각각의 화면 사이즈
<img width="432" alt="image" src="https://github.com/GYURI-PARK/Indieplus_Pohang/assets/93391058/fcc6632d-50dc-4df8-8303-079baa25943a">

기존에 `BottomBarView`와 `FastTicketingView`는 offset에 상수값을 쓰고 있었기 때문에 다음과 같이 화면 크기에 따라 제대로 보이지 않는다는 문제점이 있었습니다. 
<img width="696" alt="image" src="https://github.com/GYURI-PARK/Indieplus_Pohang/assets/93391058/3355672d-0422-4287-9fba-6a77e09b37ce">

기기 사이즈에 맞는 offset에 필요한 Double값을 반환합니다.
```swift
struct Constants {

    static var bottomOffset: Double {
        switch UIScreen.main.bounds.size {
        case CGSize(width: 430, height: 932): // 14 Pro Max
            return 370.0
        case CGSize(width: 393, height: 852): // 14 Pro
            return 350.0
        case CGSize(width: 428, height: 926): // 14 Plus, 13 Pro Max, 12 Pro Max
            return 370.0
        case CGSize(width: 390, height: 844): // 14, 13 Pro, 13, 12 Pro, 12
            return 350.0
        case CGSize(width: 375, height: 667): // SE
            return 265.0
        case CGSize(width: 375, height: 812): // 13 Mini, 12 Mini, 11 Pro, XS
            return 330.0
        case CGSize(width: 375, height: 780): // 13 Mini, 12 Mini
            return 330.0
        case CGSize(width: 414, height: 896): // 11 Pro Max, 11, XS Max, XR
            return 365.0
        default:
            return 250.0
        }
    }
}
```

BottomBarView에서 GeometryReader를 사용해 기기 별 반환되는 값을 더해줌으로써 알맞은 UI를 보여줍니다.
```swift
.offset(y: geometry.size.height / 2 + Constants.bottomOffset)
```

FastTicketingView에서도 마찬가지로 GeometryReader를 사용하고 BottomBarView의 상단에 위치하도록 합니다.
```swift
.offset(x: geometry.size.width - 100, y: geometry.size.height / 2 + Constants.bottomOffset - 60)
```

## 📱 Screenshots
<img width="580" alt="image" src="https://github.com/GYURI-PARK/Indieplus_Pohang/assets/93391058/973ede5b-0129-4c3a-984c-e1b7e34fedbe">
